### PR TITLE
Add collapsible rows to Vuetify tables

### DIFF
--- a/src/examples/AttendanceTable.tsx
+++ b/src/examples/AttendanceTable.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  Menu,
+  MenuItem,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Typography,
+  Collapse,
+} from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+
+export interface AttendanceRecord {
+  id: number;
+  clientName: string;
+  workshopName: string;
+  date?: string;
+  notes?: string;
+  [key: string]: any;
+}
+
+const initialRecords: AttendanceRecord[] = [
+  {
+    id: 1,
+    clientName: 'John Doe',
+    workshopName: 'React Basics',
+    date: '2024-04-01',
+    notes: 'Completed project',
+  },
+  {
+    id: 2,
+    clientName: 'Jane Smith',
+    workshopName: 'Advanced Vue',
+    date: '2024-04-05',
+    notes: 'Needs follow up',
+  },
+];
+
+const AttendanceTable: React.FC = () => {
+  const [records, setRecords] = useState<AttendanceRecord[]>(initialRecords);
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const handleExpand = (id: number) => {
+    setExpanded(expanded === id ? null : id);
+  };
+
+  const handleMenuOpen = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    id: number
+  ) => {
+    setAnchorEl(event.currentTarget);
+    setSelectedId(id);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setSelectedId(null);
+  };
+
+  const handleDelete = () => {
+    if (selectedId !== null) {
+      setRecords(records.filter((r) => r.id !== selectedId));
+    }
+    handleMenuClose();
+  };
+
+  return (
+    <TableContainer component={Paper} sx={{ width: '100%', overflowX: 'auto' }}>
+      <Table size="small" aria-label="attendance table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Client</TableCell>
+            <TableCell>Workshop</TableCell>
+            <TableCell align="right"></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {records.map((record) => (
+            <React.Fragment key={record.id}>
+              <TableRow>
+                <TableCell>{record.clientName}</TableCell>
+                <TableCell>{record.workshopName}</TableCell>
+                <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+                  <IconButton
+                    aria-label="view details"
+                    size="small"
+                    onClick={() => handleExpand(record.id)}
+                  >
+                    <VisibilityIcon />
+                  </IconButton>
+                  <IconButton
+                    aria-label="options"
+                    size="small"
+                    onClick={(e) => handleMenuOpen(e, record.id)}
+                  >
+                    <MoreVertIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={3}>
+                  <Collapse in={expanded === record.id} timeout="auto" unmountOnExit>
+                    <Accordion
+                      elevation={0}
+                      expanded={expanded === record.id}
+                      sx={{
+                        p: 0,
+                        '&:before': { display: 'none' },
+                      }}
+                    >
+                      <AccordionSummary
+                        sx={{ display: 'none' }}
+                      />
+                      <AccordionDetails>
+                        <Box sx={{ display: 'flex', flexDirection: 'column', rowGap: 0.5 }}>
+                          {Object.entries(record).map(([key, value]) => {
+                            if (key === 'id' || key === 'clientName' || key === 'workshopName') {
+                              return null;
+                            }
+                            return (
+                              <Typography variant="body2" key={key}>
+                                <strong>{key}:</strong> {String(value)}
+                              </Typography>
+                            );
+                          })}
+                        </Box>
+                      </AccordionDetails>
+                    </Accordion>
+                  </Collapse>
+                </TableCell>
+              </TableRow>
+            </React.Fragment>
+          ))}
+        </TableBody>
+      </Table>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleMenuClose}
+      >
+        <MenuItem onClick={handleDelete}>Delete</MenuItem>
+      </Menu>
+    </TableContainer>
+  );
+};
+
+export default AttendanceTable;
+

--- a/src/views/AsistenciasView.vue
+++ b/src/views/AsistenciasView.vue
@@ -1,13 +1,38 @@
 <template>
   <v-container>
     <v-btn color="primary" @click="startCreate" class="mb-4">Nueva Asistencia</v-btn>
-    <v-data-table :items="asistenciasStore.asistencias" :headers="headers" item-key="cliente">
-      <template #item.actions="{ item, index }">
-        <v-btn icon="mdi-pencil" @click="editItem(index)" color="primary"></v-btn>
-        <v-btn icon="mdi-delete" @click="asistenciasStore.remove(index)" color="error"></v-btn>
-        <router-link :to="{ path: '/pagos', query: { cliente: item.cliente } }">
-          <v-btn small>Ver pagos</v-btn>
-        </router-link>
+    <v-data-table
+      :items="asistenciasStore.asistencias"
+      :headers="headers"
+      item-value="cliente"
+      show-expand
+      expand-icon="mdi-eye"
+      v-model:expanded="expanded"
+    >
+      <template #item.actions="{ index }">
+        <v-menu>
+          <template #activator="{ props }">
+            <v-btn icon="mdi-dots-vertical" v-bind="props"></v-btn>
+          </template>
+          <v-list>
+            <v-list-item @click="editItem(index)">Editar</v-list-item>
+            <v-list-item @click="asistenciasStore.remove(index)" class="text-error">Eliminar</v-list-item>
+          </v-list>
+        </v-menu>
+      </template>
+      <template #expanded-row="{ item, columns }">
+        <tr>
+          <td :colspan="columns.length">
+            <div class="d-flex flex-column ga-1">
+              <div v-for="(value, key) in item" :key="key" v-if="!['cliente','taller'].includes(key)">
+                <strong>{{ key }}:</strong> {{ value }}
+              </div>
+              <router-link :to="{ path: '/pagos', query: { cliente: item.cliente } }">
+                <v-btn small class="mt-2">Ver pagos</v-btn>
+              </router-link>
+            </div>
+          </td>
+        </tr>
       </template>
     </v-data-table>
 
@@ -25,12 +50,11 @@ import { useAsistenciasStore, Asistencia } from '../stores/asistencias'
 const asistenciasStore = useAsistenciasStore()
 const dialog = ref(false)
 const current = ref<Asistencia | null>(null)
+const expanded = ref<Asistencia[]>([])
 
 const headers = [
   { title: 'Cliente', key: 'cliente' },
-  { title: 'Asistente', key: 'asistente' },
   { title: 'Taller', key: 'taller' },
-  { title: 'Diseño Realizado', key: 'disenoRealizado' },
   { title: 'Acciones', key: 'actions', sortable: false }
 ]
 

--- a/src/views/PagosView.vue
+++ b/src/views/PagosView.vue
@@ -1,13 +1,38 @@
 <template>
   <v-container>
     <v-btn color="primary" @click="startCreate" class="mb-4">Nuevo Cliente</v-btn>
-    <v-data-table :items="pagosStore.pagos" :headers="headers" item-key="cliente">
-      <template #item.actions="{ item, index }">
-        <v-btn icon="mdi-pencil" @click="editItem(index)" color="primary"></v-btn>
-        <v-btn icon="mdi-delete" @click="pagosStore.remove(index)" color="error"></v-btn>
-        <router-link :to="{ path: '/asistencias', query: { cliente: item.cliente } }">
-          <v-btn small>Ver asistencias</v-btn>
-        </router-link>
+    <v-data-table
+      :items="pagosStore.pagos"
+      :headers="headers"
+      item-value="cliente"
+      show-expand
+      expand-icon="mdi-eye"
+      v-model:expanded="expanded"
+    >
+      <template #item.actions="{ index }">
+        <v-menu>
+          <template #activator="{ props }">
+            <v-btn icon="mdi-dots-vertical" v-bind="props"></v-btn>
+          </template>
+          <v-list>
+            <v-list-item @click="editItem(index)">Editar</v-list-item>
+            <v-list-item @click="pagosStore.remove(index)" class="text-error">Eliminar</v-list-item>
+          </v-list>
+        </v-menu>
+      </template>
+      <template #expanded-row="{ item, columns }">
+        <tr>
+          <td :colspan="columns.length">
+            <div class="d-flex flex-column ga-1">
+              <div v-for="(value, key) in item" :key="key" v-if="!['cliente','contacto'].includes(key)">
+                <strong>{{ key }}:</strong> {{ value }}
+              </div>
+              <router-link :to="{ path: '/asistencias', query: { cliente: item.cliente } }">
+                <v-btn small class="mt-2">Ver asistencias</v-btn>
+              </router-link>
+            </div>
+          </td>
+        </tr>
       </template>
     </v-data-table>
 
@@ -25,13 +50,11 @@ import { usePagosStore, Pago } from '../stores/pagos'
 const pagosStore = usePagosStore()
 const dialog = ref(false)
 const current = ref<Pago | null>(null)
+const expanded = ref<Pago[]>([])
 
 const headers = [
   { title: 'Cliente', key: 'cliente' },
   { title: 'Contacto', key: 'contacto' },
-  { title: 'Pago1', key: 'pago1' },
-  { title: 'Pago2', key: 'pago2' },
-  { title: 'Pendientes', key: 'pendientes' },
   { title: 'Acciones', key: 'actions', sortable: false }
 ]
 


### PR DESCRIPTION
## Summary
- integrate collapsible Material-style tables into existing Vuetify views
- add three‑dot menus with edit & delete options

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687af67d0c6c832f8713962c550f1078