### PR TITLE
Switch stores to Google Sheets API

### DIFF
--- a/src/stores/AGENTS.md
+++ b/src/stores/AGENTS.md
@@ -1,3 +1,10 @@
 # Instrucciones para agentes
 
-Define los stores de Pinia para `pagos` y `asistencias`. Cada store persiste su estado en `localStorage` y ofrece una función `fetchRemote` para sincronizar con Google Sheets mediante la API.
+Define los stores de Pinia para `pagos` y `asistencias`. Cada store persiste su
+estado en `localStorage` y ofrece una función `fetchRemote` para sincronizar con
+Google Sheets mediante la API.
+
+Ahora ambos stores utilizan directamente el API de Google Sheets en lugar del
+script de Google Apps Script. Se añadieron constantes `SPREADSHEET_ID`,
+`API_KEY`, `API_BASE` y `SHEET_NAME` para configurar la llamada y construir la
+URL del rango a leer.


### PR DESCRIPTION
## Summary
- change pago/asistencias stores to use Google Sheets API
- add configuration constants to both stores
- remove use of JSONP with Apps Script
- update stores AGENTS notes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6882ee2378d0832fb58fb6176d8ce96d