### PR TITLE
Add secrets file and load keys in stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 android/
+src/secrets.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Instrucciones para agentes
+
+- Usa `src/secrets.ts` para definir `SPREADSHEET_ID`, `API_KEY` y `API_BASE`.
+- El archivo real `src/secrets.ts` no se debe versionar. Utiliza la plantilla
+  `src/secrets.example.ts` como base.
+- Los stores de Pinia importan estas constantes desde `../secrets` y cada uno
+  define su propia constante `SHEET_NAME`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Aplicación base en Vue 3 + Vuetify diseñada para ser compilada con Capacitor a Android. Por defecto maneja los pagos y asistencias de forma local (sin backend) usando `localStorage`.  
 Opcionalmente puede sincronizarse con Google Sheets a través del script ubicado en `appScript/script.gs`.
+Las credenciales necesarias para la API se guardan en un archivo `src/secrets.ts` que no se versiona. Utiliza la plantilla `src/secrets.example.ts` para crear tus propias claves.
 
 ## Instalación
 

--- a/src/secrets.example.ts
+++ b/src/secrets.example.ts
@@ -1,0 +1,6 @@
+// Copia este archivo a `secrets.ts` y reemplaza los valores con tus credenciales.
+// Este archivo se mantiene en control de versiones solo como referencia.
+
+export const SPREADSHEET_ID = ''
+export const API_KEY = ''
+export const API_BASE = 'https://sheets.googleapis.com/v4/spreadsheets'

--- a/src/stores/asistencias.ts
+++ b/src/stores/asistencias.ts
@@ -15,9 +15,8 @@ export interface Asistencia {
 const STORAGE_KEY = 'asistencias'
 
 // Configuración para consumir la API de Google Sheets
-const SPREADSHEET_ID = '1iPSpOidH44Qev9Woho-VfcAiRXxpn79AT1KgIBkAfTM'
-const API_KEY = 'AIzaSyBnP_Bd7VsKsRZ0KfhdGoS7p30oS91iHhk'
-const API_BASE = 'https://sheets.googleapis.com/v4/spreadsheets'
+import { SPREADSHEET_ID, API_KEY, API_BASE } from '../secrets'
+
 const SHEET_NAME = 'asistencias'
 
 export const useAsistenciasStore = defineStore('asistencias', () => {

--- a/src/stores/pagos.ts
+++ b/src/stores/pagos.ts
@@ -15,9 +15,8 @@ export interface Pago {
 const STORAGE_KEY = 'pagos'
 
 // Configuración para consumir la API de Google Sheets
-const SPREADSHEET_ID = '1iPSpOidH44Qev9Woho-VfcAiRXxpn79AT1KgIBkAfTM'
-const API_KEY = 'AIzaSyBnP_Bd7VsKsRZ0KfhdGoS7p30oS91iHhk'
-const API_BASE = 'https://sheets.googleapis.com/v4/spreadsheets'
+import { SPREADSHEET_ID, API_KEY, API_BASE } from '../secrets'
+
 const SHEET_NAME = 'pagos'
 
 export const usePagosStore = defineStore('pagos', () => {


### PR DESCRIPTION
## Summary
- create `src/secrets.example.ts` as template for API keys
- ignore `src/secrets.ts` in git
- import secrets into Pinia stores
- document secret file usage in README
- add root AGENTS instructions

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6882f7cd91e8832f9919470e467e34f9