### PR TITLE
Integrate CRUD with Google Sheets

### DIFF
--- a/src/stores/AGENTS.md
+++ b/src/stores/AGENTS.md
@@ -8,3 +8,8 @@ Ahora ambos stores utilizan directamente el API de Google Sheets en lugar del
 script de Google Apps Script. Se añadieron constantes `SPREADSHEET_ID`,
 `API_KEY`, `API_BASE` y `SHEET_NAME` para configurar la llamada y construir la
 URL del rango a leer.
+
+Las funciones `add` y `remove` también actualizan la hoja. El método `add`
+utiliza la operación `append` de Google Sheets para insertar una nueva fila y
+`remove` emplea `batchUpdate` con `deleteDimension` para borrar la fila
+correspondiente.

--- a/src/stores/asistencias.ts
+++ b/src/stores/asistencias.ts
@@ -18,9 +18,11 @@ const STORAGE_KEY = 'asistencias'
 import { SPREADSHEET_ID, API_KEY, API_BASE } from '../secrets'
 
 const SHEET_NAME = 'asistencias'
+let sheetId: number | null = null
 
 export const useAsistenciasStore = defineStore('asistencias', () => {
   const asistencias = ref<Asistencia[]>(JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]"))
+  const headers = ref<string[]>([])
 
   watch(asistencias, (val) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(val))
@@ -28,6 +30,7 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
 
   function add(asistencia: Asistencia) {
     asistencias.value.push(asistencia)
+    appendRemote(asistencia)
   }
 
   function update(index: number, asistencia: Asistencia) {
@@ -36,6 +39,7 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
 
   function remove(index: number) {
     asistencias.value.splice(index, 1)
+    deleteRemote(index)
   }
 
   async function fetchRemote() {
@@ -45,10 +49,11 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
       const resp = await fetch(url)
       const data = await resp.json()
       if (Array.isArray(data.values)) {
-        const [headers, ...rows] = data.values
+        const [hrow, ...rows] = data.values
+        headers.value = hrow
         asistencias.value = rows.map(row => {
           const item: any = {}
-          headers.forEach((h: string, i: number) => {
+          hrow.forEach((h: string, i: number) => {
             item[h] = row[i] || ''
           })
           return item as Asistencia
@@ -57,6 +62,68 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
         throw new Error('Respuesta inesperada')
       }
     } catch (err: any) {
+      console.error(err)
+    }
+  }
+
+  async function getSheetId() {
+    if (sheetId !== null) return sheetId
+    try {
+      const metaUrl = `${API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties&key=${API_KEY}`
+      const resp = await fetch(metaUrl)
+      const data = await resp.json()
+      const sheet = data.sheets.find((s: any) => s.properties.title === SHEET_NAME)
+      sheetId = sheet.properties.sheetId
+      return sheetId
+    } catch (err) {
+      console.error(err)
+      return null
+    }
+  }
+
+  async function appendRemote(asistencia: Asistencia) {
+    if (!headers.value.length) return
+    const range = `${SHEET_NAME}!A:Z`
+    const url = `${API_BASE}/${SPREADSHEET_ID}/values/${encodeURIComponent(range)}:append?valueInputOption=USER_ENTERED&key=${API_KEY}`
+    const body = {
+      values: [headers.value.map(h => (asistencia as any)[h] || '')]
+    }
+    try {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function deleteRemote(index: number) {
+    const id = await getSheetId()
+    if (id === null) return
+    const url = `${API_BASE}/${SPREADSHEET_ID}:batchUpdate?key=${API_KEY}`
+    const body = {
+      requests: [
+        {
+          deleteDimension: {
+            range: {
+              sheetId: id,
+              dimension: 'ROWS',
+              startIndex: index + 1,
+              endIndex: index + 2
+            }
+          }
+        }
+      ]
+    }
+    try {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+    } catch (err) {
       console.error(err)
     }
   }

--- a/src/stores/pagos.ts
+++ b/src/stores/pagos.ts
@@ -18,15 +18,18 @@ const STORAGE_KEY = 'pagos'
 import { SPREADSHEET_ID, API_KEY, API_BASE } from '../secrets'
 
 const SHEET_NAME = 'pagos'
+let sheetId: number | null = null
 
 export const usePagosStore = defineStore('pagos', () => {
   const pagos = ref<Pago[]>(JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]"))
+  const headers = ref<string[]>([])
   watch(pagos, (val) => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(val))
   }, { deep: true })
 
   function add(pago: Pago) {
     pagos.value.push(pago)
+    appendRemote(pago)
   }
 
   function update(index: number, pago: Pago) {
@@ -35,6 +38,7 @@ export const usePagosStore = defineStore('pagos', () => {
 
   function remove(index: number) {
     pagos.value.splice(index, 1)
+    deleteRemote(index)
   }
 
   async function fetchRemote() {
@@ -44,10 +48,11 @@ export const usePagosStore = defineStore('pagos', () => {
       const resp = await fetch(url)
       const data = await resp.json()
       if (Array.isArray(data.values)) {
-        const [headers, ...rows] = data.values
+        const [hrow, ...rows] = data.values
+        headers.value = hrow
         pagos.value = rows.map(row => {
           const item: any = {}
-          headers.forEach((h: string, i: number) => {
+          hrow.forEach((h: string, i: number) => {
             item[h] = row[i] || ''
           })
           return item as Pago
@@ -59,7 +64,69 @@ export const usePagosStore = defineStore('pagos', () => {
       console.error(err)
     }
   }
-  
 
+  async function getSheetId() {
+    if (sheetId !== null) return sheetId
+    try {
+      const metaUrl = `${API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties&key=${API_KEY}`
+      const resp = await fetch(metaUrl)
+      const data = await resp.json()
+      const sheet = data.sheets.find((s: any) => s.properties.title === SHEET_NAME)
+      sheetId = sheet.properties.sheetId
+      return sheetId
+    } catch (err) {
+      console.error(err)
+      return null
+    }
+  }
+
+  async function appendRemote(pago: Pago) {
+    if (!headers.value.length) return
+    const range = `${SHEET_NAME}!A:Z`
+    const url = `${API_BASE}/${SPREADSHEET_ID}/values/${encodeURIComponent(range)}:append?valueInputOption=USER_ENTERED&key=${API_KEY}`
+    const body = {
+      values: [headers.value.map(h => (pago as any)[h] || '')]
+    }
+    try {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function deleteRemote(index: number) {
+    const id = await getSheetId()
+    if (id === null) return
+    const url = `${API_BASE}/${SPREADSHEET_ID}:batchUpdate?key=${API_KEY}`
+    const body = {
+      requests: [
+        {
+          deleteDimension: {
+            range: {
+              sheetId: id,
+              dimension: 'ROWS',
+              startIndex: index + 1,
+              endIndex: index + 2
+            }
+          }
+        }
+      ]
+    }
+    try {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  
   return { pagos, add, update, remove, fetchRemote }
 })


### PR DESCRIPTION
## Summary
- connect add/remove actions in stores with the Google Sheets API
- store sheet headers to append new rows
- fetch metadata to delete rows via `batchUpdate`
- document new remote behaviour in `AGENTS.md`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6882fa6be104832fbf430cf89d57ba53