### PR TITLE
Update stores with OAuth credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Instrucciones para agentes
 
-- Usa `src/secrets.ts` para definir `SPREADSHEET_ID`, `API_KEY` y `API_BASE`.
+- Usa `src/secrets.ts` para definir `SPREADSHEET_ID`, `API_KEY`, `API_BASE` y los datos de OAuth (`OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_ACCESS_TOKEN`, etc.).
 - El archivo real `src/secrets.ts` no se debe versionar. Utiliza la plantilla
   `src/secrets.example.ts` como base.
 - Los stores de Pinia importan estas constantes desde `../secrets` y cada uno

--- a/src/secrets.example.ts
+++ b/src/secrets.example.ts
@@ -4,3 +4,13 @@
 export const SPREADSHEET_ID = ''
 export const API_KEY = ''
 export const API_BASE = 'https://sheets.googleapis.com/v4/spreadsheets'
+
+// Datos de OAuth2 para acceder a Google Sheets
+export const OAUTH_CLIENT_ID = ''
+export const OAUTH_CLIENT_SECRET = ''
+export const OAUTH_AUTH_URI = 'https://accounts.google.com/o/oauth2/auth'
+export const OAUTH_TOKEN_URI = 'https://oauth2.googleapis.com/token'
+export const OAUTH_PROVIDER_CERT_URL = 'https://www.googleapis.com/oauth2/v1/certs'
+export const OAUTH_JAVASCRIPT_ORIGIN = 'http://localhost:3000'
+// Token de acceso generado mediante OAuth2
+export const OAUTH_ACCESS_TOKEN = ''

--- a/src/stores/AGENTS.md
+++ b/src/stores/AGENTS.md
@@ -6,8 +6,9 @@ Google Sheets mediante la API.
 
 Ahora ambos stores utilizan directamente el API de Google Sheets en lugar del
 script de Google Apps Script. Se añadieron constantes `SPREADSHEET_ID`,
-`API_KEY`, `API_BASE` y `SHEET_NAME` para configurar la llamada y construir la
-URL del rango a leer.
+`API_KEY`, `API_BASE`, `OAUTH_ACCESS_TOKEN` y `SHEET_NAME` para configurar la
+llamada y construir la URL del rango a leer. Para operaciones de escritura se
+envía la cabecera `Authorization: Bearer <token>` usando dicho valor de OAuth.
 
 Las funciones `add` y `remove` también actualizan la hoja. El método `add`
 utiliza la operación `append` de Google Sheets para insertar una nueva fila y

--- a/src/stores/asistencias.ts
+++ b/src/stores/asistencias.ts
@@ -15,7 +15,7 @@ export interface Asistencia {
 const STORAGE_KEY = 'asistencias'
 
 // Configuración para consumir la API de Google Sheets
-import { SPREADSHEET_ID, API_KEY, API_BASE } from '../secrets'
+import { SPREADSHEET_ID, API_KEY, API_BASE, OAUTH_ACCESS_TOKEN } from '../secrets'
 
 const SHEET_NAME = 'asistencias'
 let sheetId: number | null = null
@@ -45,8 +45,10 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
   async function fetchRemote() {
     try {
       const range = `${SHEET_NAME}!A:Z`
-      const url = `${API_BASE}/${SPREADSHEET_ID}/values/${encodeURIComponent(range)}?key=${API_KEY}`
-      const resp = await fetch(url)
+    const url = `${API_BASE}/${SPREADSHEET_ID}/values/${encodeURIComponent(range)}?key=${API_KEY}`
+    const resp = await fetch(url, {
+      headers: { 'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}` }
+    })
       const data = await resp.json()
       if (Array.isArray(data.values)) {
         const [hrow, ...rows] = data.values
@@ -69,8 +71,10 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
   async function getSheetId() {
     if (sheetId !== null) return sheetId
     try {
-      const metaUrl = `${API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties&key=${API_KEY}`
-      const resp = await fetch(metaUrl)
+    const metaUrl = `${API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties&key=${API_KEY}`
+    const resp = await fetch(metaUrl, {
+      headers: { 'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}` }
+    })
       const data = await resp.json()
       const sheet = data.sheets.find((s: any) => s.properties.title === SHEET_NAME)
       sheetId = sheet.properties.sheetId
@@ -91,7 +95,10 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
     try {
       await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}`
+        },
         body: JSON.stringify(body)
       })
     } catch (err) {
@@ -120,7 +127,10 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
     try {
       await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}`
+        },
         body: JSON.stringify(body)
       })
     } catch (err) {

--- a/src/stores/pagos.ts
+++ b/src/stores/pagos.ts
@@ -15,7 +15,7 @@ export interface Pago {
 const STORAGE_KEY = 'pagos'
 
 // Configuración para consumir la API de Google Sheets
-import { SPREADSHEET_ID, API_KEY, API_BASE } from '../secrets'
+import { SPREADSHEET_ID, API_KEY, API_BASE, OAUTH_ACCESS_TOKEN } from '../secrets'
 
 const SHEET_NAME = 'pagos'
 let sheetId: number | null = null
@@ -44,8 +44,10 @@ export const usePagosStore = defineStore('pagos', () => {
   async function fetchRemote() {
     try {
       const range = `${SHEET_NAME}!A:Z`
-      const url = `${API_BASE}/${SPREADSHEET_ID}/values/${encodeURIComponent(range)}?key=${API_KEY}`
-      const resp = await fetch(url)
+    const url = `${API_BASE}/${SPREADSHEET_ID}/values/${encodeURIComponent(range)}?key=${API_KEY}`
+    const resp = await fetch(url, {
+      headers: { 'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}` }
+    })
       const data = await resp.json()
       if (Array.isArray(data.values)) {
         const [hrow, ...rows] = data.values
@@ -68,8 +70,10 @@ export const usePagosStore = defineStore('pagos', () => {
   async function getSheetId() {
     if (sheetId !== null) return sheetId
     try {
-      const metaUrl = `${API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties&key=${API_KEY}`
-      const resp = await fetch(metaUrl)
+    const metaUrl = `${API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties&key=${API_KEY}`
+    const resp = await fetch(metaUrl, {
+      headers: { 'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}` }
+    })
       const data = await resp.json()
       const sheet = data.sheets.find((s: any) => s.properties.title === SHEET_NAME)
       sheetId = sheet.properties.sheetId
@@ -90,7 +94,10 @@ export const usePagosStore = defineStore('pagos', () => {
     try {
       await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}`
+        },
         body: JSON.stringify(body)
       })
     } catch (err) {
@@ -119,7 +126,10 @@ export const usePagosStore = defineStore('pagos', () => {
     try {
       await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}`
+        },
         body: JSON.stringify(body)
       })
     } catch (err) {


### PR DESCRIPTION
## Summary
- add OAuth credentials placeholders in `src/secrets.example.ts`
- document OAuth secrets usage in `AGENTS.md` files
- update stores to send `Authorization: Bearer` headers

## Testing
- `npm install`
- `npx vite build`

------
https://chatgpt.com/codex/tasks/task_b_68830a25d51c832fb2b26ada12df8376