### PR TITLE
Improve popup form usability

### DIFF
--- a/src/components/AsistenciaForm.vue
+++ b/src/components/AsistenciaForm.vue
@@ -1,16 +1,27 @@
 <template>
-  <v-form @submit.prevent="onSubmit" ref="formRef">
-    <v-text-field v-model="form.cliente" label="Cliente" :rules="[v=>!!v||'Requerido']" required></v-text-field>
-    <v-text-field v-model="form.asistente" label="Asistente"></v-text-field>
-    <v-text-field v-model="form.taller" label="Taller"></v-text-field>
-    <v-text-field v-model="form.disenoElegido" label="Diseño Elegido"></v-text-field>
-    <v-text-field v-model="form.disenoApoyo" label="Diseño Apoyo"></v-text-field>
-    <v-text-field v-model="form.disenoRealizado" label="Diseño Realizado"></v-text-field>
-    <v-text-field v-model="form.bienvenida" label="Bienvenida"></v-text-field>
-    <v-text-field v-model="form.recordatorio" label="Recordatorio"></v-text-field>
-    <v-btn type="submit" color="primary" class="mt-2">Guardar</v-btn>
-    <v-btn @click="$emit('cancel')" class="mt-2">Cancelar</v-btn>
-  </v-form>
+  <v-card color="white" class="pa-4" style="max-height: 90vh;">
+    <v-form
+      @submit.prevent="onSubmit"
+      ref="formRef"
+      class="d-flex flex-column"
+      style="height: 100%"
+    >
+      <div class="flex-grow-1 overflow-y-auto">
+        <v-text-field v-model="form.cliente" label="Cliente" :rules="[v=>!!v||'Requerido']" required></v-text-field>
+        <v-text-field v-model="form.asistente" label="Asistente"></v-text-field>
+        <v-text-field v-model="form.taller" label="Taller"></v-text-field>
+        <v-text-field v-model="form.disenoElegido" label="Diseño Elegido"></v-text-field>
+        <v-text-field v-model="form.disenoApoyo" label="Diseño Apoyo"></v-text-field>
+        <v-text-field v-model="form.disenoRealizado" label="Diseño Realizado"></v-text-field>
+        <v-text-field v-model="form.bienvenida" label="Bienvenida"></v-text-field>
+        <v-text-field v-model="form.recordatorio" label="Recordatorio"></v-text-field>
+      </div>
+      <div class="d-flex justify-end mt-4">
+        <v-btn type="submit" color="primary" class="mr-2">Guardar</v-btn>
+        <v-btn @click="$emit('cancel')">Cancelar</v-btn>
+      </div>
+    </v-form>
+  </v-card>
 </template>
 
 <script setup lang="ts">

--- a/src/components/PagoForm.vue
+++ b/src/components/PagoForm.vue
@@ -1,16 +1,27 @@
 <template>
-  <v-form @submit.prevent="onSubmit" ref="formRef">
-    <v-text-field v-model="form.cliente" label="Cliente" :rules="[v=>!!v||'Requerido']" required></v-text-field>
-    <v-text-field v-model="form.contacto" label="Contacto"></v-text-field>
-    <v-text-field v-model="form.pago1" label="Pago 1"></v-text-field>
-    <v-text-field v-model="form.pago2" label="Pago 2"></v-text-field>
-    <v-text-field v-model="form.pendientes" label="Pendientes"></v-text-field>
-    <v-text-field v-model="form.correo" label="Correo"></v-text-field>
-    <v-text-field v-model="form.cedula" label="Cédula"></v-text-field>
-    <v-text-field v-model="form.telefono" label="Teléfono"></v-text-field>
-    <v-btn type="submit" color="primary" class="mt-2">Guardar</v-btn>
-    <v-btn @click="$emit('cancel')" class="mt-2">Cancelar</v-btn>
-  </v-form>
+  <v-card color="white" class="pa-4" style="max-height: 90vh;">
+    <v-form
+      @submit.prevent="onSubmit"
+      ref="formRef"
+      class="d-flex flex-column"
+      style="height: 100%"
+    >
+      <div class="flex-grow-1 overflow-y-auto">
+        <v-text-field v-model="form.cliente" label="Cliente" :rules="[v=>!!v||'Requerido']" required></v-text-field>
+        <v-text-field v-model="form.contacto" label="Contacto"></v-text-field>
+        <v-text-field v-model="form.pago1" label="Pago 1"></v-text-field>
+        <v-text-field v-model="form.pago2" label="Pago 2"></v-text-field>
+        <v-text-field v-model="form.pendientes" label="Pendientes"></v-text-field>
+        <v-text-field v-model="form.correo" label="Correo"></v-text-field>
+        <v-text-field v-model="form.cedula" label="Cédula"></v-text-field>
+        <v-text-field v-model="form.telefono" label="Teléfono"></v-text-field>
+      </div>
+      <div class="d-flex justify-end mt-4">
+        <v-btn type="submit" color="primary" class="mr-2">Guardar</v-btn>
+        <v-btn @click="$emit('cancel')">Cancelar</v-btn>
+      </div>
+    </v-form>
+  </v-card>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- keep form dialogs within screen bounds
- ensure background is opaque and white so fields are readable

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68830c8fd248832f9f1d1abf7c30dd01