### PR TITLE
Implement client-side Google OAuth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,12 @@
 # Instrucciones para agentes
 
-- Usa `src/secrets.ts` para definir `SPREADSHEET_ID`, `API_KEY`, `API_BASE` y los datos de OAuth (`OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_ACCESS_TOKEN`, etc.).
+- Usa `src/secrets.ts` para definir `SPREADSHEET_ID`, `API_KEY`, `API_BASE` y los datos de OAuth (`OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_ACCESS_TOKEN`, etc.). `OAUTH_ACCESS_TOKEN` es opcional porque ahora se puede obtener dinámicamente.
 - El archivo real `src/secrets.ts` no se debe versionar. Utiliza la plantilla
   `src/secrets.example.ts` como base.
 - Los stores de Pinia importan estas constantes desde `../secrets` y cada uno
   define su propia constante `SHEET_NAME`.
+
+- Existe un store `googleAuth` que maneja la autenticación OAuth en el cliente
+  utilizando las librerías de Google. Este store escucha los eventos
+  `gapi-loaded` y `gis-loaded` que se disparan en `index.html` al cargar los
+  scripts de Google.

--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
   </head>
   <body>
     <div id="app"></div>
+    <script>
+      window.gapiLoaded = () => window.dispatchEvent(new Event('gapi-loaded'))
+      window.gisLoaded = () => window.dispatchEvent(new Event('gis-loaded'))
+    </script>
+    <script src="https://accounts.google.com/gsi/client" async defer onload="gisLoaded()"></script>
+    <script src="https://apis.google.com/js/api.js" async defer onload="gapiLoaded()"></script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
       <v-spacer></v-spacer>
       <v-btn to="/pagos" text>Pagos</v-btn>
       <v-btn to="/asistencias" text>Asistencias</v-btn>
+      <v-btn text @click="onAuth">{{ authStore.token ? 'Cerrar sesión' : 'Iniciar sesión' }}</v-btn>
     </v-app-bar>
     <v-main class="ma-4">
       <router-view />
@@ -13,4 +14,15 @@
 </template>
 
 <script setup lang="ts">
+import { useGoogleAuthStore } from './stores/googleAuth'
+
+const authStore = useGoogleAuthStore()
+
+function onAuth() {
+  if (authStore.token) {
+    authStore.signOut()
+  } else {
+    authStore.signIn()
+  }
+}
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
+import { useGoogleAuthStore } from './stores/googleAuth'
 
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
@@ -10,4 +11,12 @@ import * as directives from 'vuetify/directives'
 
 const vuetify = createVuetify({ components, directives })
 
-createApp(App).use(router).use(createPinia()).use(vuetify).mount('#app')
+const app = createApp(App)
+const pinia = createPinia()
+app.use(router).use(pinia).use(vuetify)
+
+const authStore = useGoogleAuthStore(pinia)
+window.addEventListener('gapi-loaded', authStore.gapiLoaded)
+window.addEventListener('gis-loaded', authStore.gisLoaded)
+
+app.mount('#app')

--- a/src/secrets.example.ts
+++ b/src/secrets.example.ts
@@ -13,4 +13,5 @@ export const OAUTH_TOKEN_URI = 'https://oauth2.googleapis.com/token'
 export const OAUTH_PROVIDER_CERT_URL = 'https://www.googleapis.com/oauth2/v1/certs'
 export const OAUTH_JAVASCRIPT_ORIGIN = 'http://localhost:3000'
 // Token de acceso generado mediante OAuth2
+// (Opcional) Token estático; la app ahora obtiene uno dinámicamente con GIS
 export const OAUTH_ACCESS_TOKEN = ''

--- a/src/stores/AGENTS.md
+++ b/src/stores/AGENTS.md
@@ -5,10 +5,12 @@ estado en `localStorage` y ofrece una función `fetchRemote` para sincronizar co
 Google Sheets mediante la API.
 
 Ahora ambos stores utilizan directamente el API de Google Sheets en lugar del
-script de Google Apps Script. Se añadieron constantes `SPREADSHEET_ID`,
-`API_KEY`, `API_BASE`, `OAUTH_ACCESS_TOKEN` y `SHEET_NAME` para configurar la
-llamada y construir la URL del rango a leer. Para operaciones de escritura se
-envía la cabecera `Authorization: Bearer <token>` usando dicho valor de OAuth.
+script de Google Apps Script. Se añaden las constantes `SPREADSHEET_ID`,
+`API_KEY`, `API_BASE` y `SHEET_NAME` para configurar las URLs. El token de
+OAuth se obtiene en tiempo de ejecución a través del store `googleAuth`, por lo
+que `OAUTH_ACCESS_TOKEN` es opcional. Para operaciones de escritura se envía la
+cabecera `Authorization: Bearer <token>` usando el valor proporcionado por dicho
+store.
 
 Las funciones `add` y `remove` también actualizan la hoja. El método `add`
 utiliza la operación `append` de Google Sheets para insertar una nueva fila y

--- a/src/stores/asistencias.ts
+++ b/src/stores/asistencias.ts
@@ -15,12 +15,14 @@ export interface Asistencia {
 const STORAGE_KEY = 'asistencias'
 
 // Configuración para consumir la API de Google Sheets
-import { SPREADSHEET_ID, API_KEY, API_BASE, OAUTH_ACCESS_TOKEN } from '../secrets'
+import { SPREADSHEET_ID, API_KEY, API_BASE } from '../secrets'
+import { useGoogleAuthStore } from './googleAuth'
 
 const SHEET_NAME = 'asistencias'
 let sheetId: number | null = null
 
 export const useAsistenciasStore = defineStore('asistencias', () => {
+  const authStore = useGoogleAuthStore()
   const asistencias = ref<Asistencia[]>(JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]"))
   const headers = ref<string[]>([])
 
@@ -47,7 +49,7 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
       const range = `${SHEET_NAME}!A:Z`
     const url = `${API_BASE}/${SPREADSHEET_ID}/values/${encodeURIComponent(range)}?key=${API_KEY}`
     const resp = await fetch(url, {
-      headers: { 'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}` }
+      headers: { 'Authorization': `Bearer ${authStore.token}` }
     })
       const data = await resp.json()
       if (Array.isArray(data.values)) {
@@ -73,7 +75,7 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
     try {
     const metaUrl = `${API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties&key=${API_KEY}`
     const resp = await fetch(metaUrl, {
-      headers: { 'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}` }
+      headers: { 'Authorization': `Bearer ${authStore.token}` }
     })
       const data = await resp.json()
       const sheet = data.sheets.find((s: any) => s.properties.title === SHEET_NAME)
@@ -97,7 +99,7 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}`
+          'Authorization': `Bearer ${authStore.token}`
         },
         body: JSON.stringify(body)
       })
@@ -129,7 +131,7 @@ export const useAsistenciasStore = defineStore('asistencias', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}`
+          'Authorization': `Bearer ${authStore.token}`
         },
         body: JSON.stringify(body)
       })

--- a/src/stores/googleAuth.ts
+++ b/src/stores/googleAuth.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { API_KEY, OAUTH_CLIENT_ID } from '../secrets'
+
+declare const gapi: any
+declare const google: any
+
+const DISCOVERY_DOC = 'https://sheets.googleapis.com/$discovery/rest?version=v4'
+const SCOPES = 'https://www.googleapis.com/auth/spreadsheets'
+
+export const useGoogleAuthStore = defineStore('googleAuth', () => {
+  const token = ref<string | null>(null)
+  const gapiReady = ref(false)
+  const gisReady = ref(false)
+  let tokenClient: google.accounts.oauth2.TokenClient | null = null
+
+  async function gapiLoaded() {
+    await gapi.load('client', async () => {
+      await gapi.client.init({
+        apiKey: API_KEY,
+        discoveryDocs: [DISCOVERY_DOC],
+      })
+      gapiReady.value = true
+    })
+  }
+
+  function gisLoaded() {
+    tokenClient = google.accounts.oauth2.initTokenClient({
+      client_id: OAUTH_CLIENT_ID,
+      scope: SCOPES,
+      callback: (resp) => {
+        if (resp && resp.access_token) {
+          token.value = resp.access_token
+        }
+      },
+    })
+    gisReady.value = true
+  }
+
+  function signIn() {
+    if (gisReady.value && gapiReady.value && tokenClient) {
+      tokenClient.requestAccessToken({ prompt: 'consent' })
+    }
+  }
+
+  function signOut() {
+    token.value = null
+  }
+
+  return { token, gapiLoaded, gisLoaded, signIn, signOut }
+})

--- a/src/stores/pagos.ts
+++ b/src/stores/pagos.ts
@@ -15,12 +15,14 @@ export interface Pago {
 const STORAGE_KEY = 'pagos'
 
 // Configuración para consumir la API de Google Sheets
-import { SPREADSHEET_ID, API_KEY, API_BASE, OAUTH_ACCESS_TOKEN } from '../secrets'
+import { SPREADSHEET_ID, API_KEY, API_BASE } from '../secrets'
+import { useGoogleAuthStore } from './googleAuth'
 
 const SHEET_NAME = 'pagos'
 let sheetId: number | null = null
 
 export const usePagosStore = defineStore('pagos', () => {
+  const authStore = useGoogleAuthStore()
   const pagos = ref<Pago[]>(JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]"))
   const headers = ref<string[]>([])
   watch(pagos, (val) => {
@@ -46,7 +48,7 @@ export const usePagosStore = defineStore('pagos', () => {
       const range = `${SHEET_NAME}!A:Z`
     const url = `${API_BASE}/${SPREADSHEET_ID}/values/${encodeURIComponent(range)}?key=${API_KEY}`
     const resp = await fetch(url, {
-      headers: { 'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}` }
+      headers: { 'Authorization': `Bearer ${authStore.token}` }
     })
       const data = await resp.json()
       if (Array.isArray(data.values)) {
@@ -72,7 +74,7 @@ export const usePagosStore = defineStore('pagos', () => {
     try {
     const metaUrl = `${API_BASE}/${SPREADSHEET_ID}?fields=sheets.properties&key=${API_KEY}`
     const resp = await fetch(metaUrl, {
-      headers: { 'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}` }
+      headers: { 'Authorization': `Bearer ${authStore.token}` }
     })
       const data = await resp.json()
       const sheet = data.sheets.find((s: any) => s.properties.title === SHEET_NAME)
@@ -96,7 +98,7 @@ export const usePagosStore = defineStore('pagos', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}`
+          'Authorization': `Bearer ${authStore.token}`
         },
         body: JSON.stringify(body)
       })
@@ -128,7 +130,7 @@ export const usePagosStore = defineStore('pagos', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${OAUTH_ACCESS_TOKEN}`
+          'Authorization': `Bearer ${authStore.token}`
         },
         body: JSON.stringify(body)
       })


### PR DESCRIPTION
## Summary
- load Google scripts in `index.html`
- add Pinia store `useGoogleAuthStore` for OAuth token handling
- integrate store in `main.ts` and show login button in `App.vue`
- use dynamic token in payments and attendance stores
- update `secrets.example.ts` comment
- document OAuth store usage in AGENTS files

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68830ee185b8832f9d63a7fd1241817e