### PR TITLE
Fix missing icons in PagosView

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@capacitor/core": "^5.6.2",
+        "@mdi/font": "^7.4.47",
         "fetch-jsonp": "^1.3.0",
         "pinia": "^2.1.5",
         "vue": "^3.4.0",
@@ -707,6 +708,12 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "license": "MIT"
+    },
+    "node_modules/@mdi/font": {
+      "version": "7.4.47",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
+      "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@capacitor/core": "^5.6.2",
+    "@mdi/font": "^7.4.47",
     "fetch-jsonp": "^1.3.0",
     "pinia": "^2.1.5",
     "vue": "^3.4.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,21 @@ import router from './router'
 import { useGoogleAuthStore } from './stores/googleAuth'
 
 import 'vuetify/styles'
+import '@mdi/font/css/materialdesignicons.css'
 import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
+import { aliases, mdi } from 'vuetify/iconsets/mdi'
 
-const vuetify = createVuetify({ components, directives })
+const vuetify = createVuetify({
+  components,
+  directives,
+  icons: {
+    defaultSet: 'mdi',
+    aliases,
+    sets: { mdi },
+  },
+})
 
 const app = createApp(App)
 const pinia = createPinia()


### PR DESCRIPTION
## Summary
- add `@mdi/font` dependency for Material Design icons
- configure Vuetify to use MDI icons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6883be64ead4832f98054e38d81dce68