### PR TITLE
Make table rows toggle details on click

### DIFF
--- a/src/views/AGENTS.md
+++ b/src/views/AGENTS.md
@@ -1,3 +1,5 @@
 # Instrucciones para agentes
 
 Vistas principales de la aplicación. `PagosView.vue` y `AsistenciasView.vue` muestran tablas editables con filas expandibles y utilizan los formularios de `src/components` junto con los stores correspondientes.
+
+Las filas de las tablas se expanden haciendo clic en cualquier parte de la fila. Esto se logra con la prop `expand-on-click` del componente `v-data-table`. La columna de acciones utiliza `@click.stop` para evitar que el menú dispare la expansión.

--- a/src/views/AGENTS.md
+++ b/src/views/AGENTS.md
@@ -2,4 +2,4 @@
 
 Vistas principales de la aplicación. `PagosView.vue` y `AsistenciasView.vue` muestran tablas editables con filas expandibles y utilizan los formularios de `src/components` junto con los stores correspondientes.
 
-Las filas de las tablas se expanden haciendo clic en cualquier parte de la fila. Esto se logra con la prop `expand-on-click` del componente `v-data-table`. La columna de acciones utiliza `@click.stop` para evitar que el menú dispare la expansión.
+Las filas de las tablas se expanden haciendo clic en cualquier parte de la fila. Se usa la prop `expand-on-click` y se captura `update:expanded` para mantener solo una fila abierta a la vez. La columna de acciones utiliza `@click.stop` para evitar que el menú dispare la expansión.

--- a/src/views/AGENTS.md
+++ b/src/views/AGENTS.md
@@ -3,3 +3,5 @@
 Vistas principales de la aplicación. `PagosView.vue` y `AsistenciasView.vue` muestran tablas editables con filas expandibles y utilizan los formularios de `src/components` junto con los stores correspondientes.
 
 Las filas de las tablas se expanden haciendo clic en cualquier parte de la fila. Se usa la prop `expand-on-click` y se captura `update:expanded` para mantener solo una fila abierta a la vez. La columna de acciones utiliza `@click.stop` para evitar que el menú dispare la expansión.
+
+Al iterar sobre las propiedades de un item dentro de la fila expandida se emplea `field` como alias en lugar de `key` para prevenir el warning de Vue por usar la palabra reservada `key`.

--- a/src/views/AsistenciasView.vue
+++ b/src/views/AsistenciasView.vue
@@ -25,8 +25,8 @@
         <tr>
           <td :colspan="columns.length">
             <div class="d-flex flex-column ga-1">
-              <div v-for="(value, key) in item" :key="key" v-if="!['asistente','ilustracion'].includes(key)">
-                <strong>{{ key }}:</strong> {{ value }}
+              <div v-for="(value, field) in item" :key="field" v-if="!['asistente','ilustracion'].includes(field)">
+                <strong>{{ field }}:</strong> {{ value }}
               </div>
               <router-link :to="{ path: '/pagos', query: { cliente: item.cliente } }">
                 <v-btn small class="mt-2">Ver pagos</v-btn>

--- a/src/views/AsistenciasView.vue
+++ b/src/views/AsistenciasView.vue
@@ -4,10 +4,11 @@
     <v-data-table
       :items="asistenciasStore.asistencias"
       :headers="headers"
-      item-value="cliente"
+      item-value="id"
       expand-on-click
       :item-props="() => ({ class: 'cursor-pointer' })"
       v-model:expanded="expanded"
+      @update:expanded="onExpanded"
     >
       <template #item.actions="{ index }">
         <v-menu @click.stop>
@@ -50,7 +51,11 @@ import { useAsistenciasStore, Asistencia } from '../stores/asistencias'
 const asistenciasStore = useAsistenciasStore()
 const dialog = ref(false)
 const current = ref<Asistencia | null>(null)
-const expanded = ref<Asistencia[]>([])
+const expanded = ref<string[]>([])
+
+function onExpanded(ids: string[]) {
+  expanded.value = ids.length ? [ids.at(-1)!] : []
+}
 
 onMounted(() => {
   asistenciasStore.fetchRemote()

--- a/src/views/AsistenciasView.vue
+++ b/src/views/AsistenciasView.vue
@@ -5,18 +5,18 @@
       :items="asistenciasStore.asistencias"
       :headers="headers"
       item-value="cliente"
-      show-expand
-      expand-icon="mdi-eye"
+      expand-on-click
+      :item-props="() => ({ class: 'cursor-pointer' })"
       v-model:expanded="expanded"
     >
       <template #item.actions="{ index }">
-        <v-menu>
+        <v-menu @click.stop>
           <template #activator="{ props }">
-            <v-btn icon="mdi-dots-vertical" v-bind="props"></v-btn>
+            <v-btn icon="mdi-dots-vertical" v-bind="props" @click.stop></v-btn>
           </template>
           <v-list>
-            <v-list-item @click="editItem(index)">Editar</v-list-item>
-            <v-list-item @click="asistenciasStore.remove(index)" class="text-error">Eliminar</v-list-item>
+            <v-list-item @click.stop="editItem(index)">Editar</v-list-item>
+            <v-list-item @click.stop="asistenciasStore.remove(index)" class="text-error">Eliminar</v-list-item>
           </v-list>
         </v-menu>
       </template>

--- a/src/views/PagosView.vue
+++ b/src/views/PagosView.vue
@@ -25,8 +25,8 @@
         <tr>
           <td :colspan="columns.length">
             <div class="d-flex flex-column ga-1">
-              <div v-for="(value, key) in item" :key="key" v-if="!['cliente', 'deuda', 'contacto'].includes(key)">
-                <strong>{{ key }}:</strong> {{ value }}
+              <div v-for="(value, field) in item" :key="field" v-if="!['cliente', 'deuda', 'contacto'].includes(field)">
+                <strong>{{ field }}:</strong> {{ value }}
               </div>
               <router-link :to="{ path: '/asistencias', query: { cliente: item.idCliente } }">
                 <v-btn small class="mt-2">Ver asistencias</v-btn>

--- a/src/views/PagosView.vue
+++ b/src/views/PagosView.vue
@@ -4,10 +4,11 @@
     <v-data-table
       :items="pagosStore.pagos"
       :headers="headers"
-      item-value="cliente"
+      item-value="idCliente"
       expand-on-click
       :item-props="() => ({ class: 'cursor-pointer' })"
       v-model:expanded="expanded"
+      @update:expanded="onExpanded"
     >
       <template #item.actions="{ index }">
         <v-menu @click.stop>
@@ -50,7 +51,11 @@ import { usePagosStore, Pago } from '../stores/pagos'
 const pagosStore = usePagosStore()
 const dialog = ref(false)
 const current = ref<Pago | null>(null)
-const expanded = ref<Pago[]>([])
+const expanded = ref<string[]>([])
+
+function onExpanded(ids: string[]) {
+  expanded.value = ids.length ? [ids.at(-1)!] : []
+}
 
 onMounted(() => {
   pagosStore.fetchRemote()

--- a/src/views/PagosView.vue
+++ b/src/views/PagosView.vue
@@ -5,18 +5,18 @@
       :items="pagosStore.pagos"
       :headers="headers"
       item-value="cliente"
-      show-expand
-      expand-icon="mdi-eye"
+      expand-on-click
+      :item-props="() => ({ class: 'cursor-pointer' })"
       v-model:expanded="expanded"
     >
       <template #item.actions="{ index }">
-        <v-menu>
+        <v-menu @click.stop>
           <template #activator="{ props }">
-            <v-btn icon="mdi-dots-vertical" v-bind="props"></v-btn>
+            <v-btn icon="mdi-dots-vertical" v-bind="props" @click.stop></v-btn>
           </template>
           <v-list>
-            <v-list-item @click="editItem(index)">Editar</v-list-item>
-            <v-list-item @click="pagosStore.remove(index)" class="text-error">Eliminar</v-list-item>
+            <v-list-item @click.stop="editItem(index)">Editar</v-list-item>
+            <v-list-item @click.stop="pagosStore.remove(index)" class="text-error">Eliminar</v-list-item>
           </v-list>
         </v-menu>
       </template>


### PR DESCRIPTION
## Summary
- expand table rows by clicking anywhere on the row
- stop propagation from the action menus
- document new behaviour in view guidelines

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6883f13e92c0832f84e11d9f74fc5cf0